### PR TITLE
Added and tested EPSON L3060 Series 

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Model not listed? See this [guide](CONTRIBUTING.md) by [@j6ta](https://github.co
 
 The key, `trial`, can be used to reset your counters to 80% for free. After packet sniffing with `wireshark`, the correct OIDs can be found.
 
-The application also stores a log containing SNMP information at `~/.wicreset/application.log` on Linux-based systems, or `%APPDATA%\wicreset\application.log` on Windows.
+The application also stores a log containing SNMP information at `~/.wicreset/application.log` on Linux-based systems, `%APPDATA%\wicreset\application.log` on Windows or `~/Library/Application Support/wicreset/` for Mac OS. 
 
 Once the log has been found, you can use `wicreset.py <path to log>` to automatically parse and guess the OID structure of your printer.
 

--- a/models.json
+++ b/models.json
@@ -93,5 +93,18 @@
     ],
     "maintenance_levels": [46],
     "unknown_oids": [30]
+  },
+  "L3060 Series": {
+    "password": [149, 3],
+    "eeprom_link": "1.3.6.1.4.1.1248.1.2.2.44.1.1.2.1",
+    "eeprom_write": "78.98.111.106.111.107.98.118",
+    "ink_levels": {},
+    "waste_inks": [
+      { "oids": [24, 25], "total": 6206.25 },
+      { "oids": [28, 29], "total": null },
+      { "oids": [26, 27], "total": 2420.0 }
+    ],
+    "maintenance_levels": [46, 47],
+    "unknown_oids": [30, 34]
   }
 }


### PR DESCRIPTION
Added and tested EPSON L3060 Series using wicreset  

  "L3060 Series": {
    "password": [149, 3],
    "eeprom_link": "1.3.6.1.4.1.1248.1.2.2.44.1.1.2.1",
    "eeprom_write": "78.98.111.106.111.107.98.118",
    "ink_levels": {},
    "waste_inks": [
      { "oids": [24, 25], "total": 6206.25 },
      { "oids": [28, 29], "total": null },
      { "oids": [26, 27], "total": 2420.0 }
    ],
    "maintenance_levels": [46, 47],
    "unknown_oids": [30, 34]
  }

Did work with wicreset.py but I had some issues with the typing so after a little bit of modification to remove some types from the functions it worked, Its likely just a dependency or configuration issue on my end, main.py worked as intended. 

Also I think I should also add this to the readme but in macos wicreset application.log to /Users/{username}/Library/Application Support/wicreset folder. 