### PR TITLE
Added EPSON ET-2750

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Read information and reset waste ink counters on Epson printers, using SNMP.
 This project was designed for a EPSON WF-7525 Series printer, but inspired by [projects](#resources) for other models.
 Hopefully, releasing this code will help save a printer from the trash and improve consumer repairability for these devices.
 Information about specific models is stored in `models.json`, as a dictionary.
-Feel free to raise an issue/pull request for adding support for another model of printer, with logs from `wicreset` or similar attached.
+Feel free to raise an issue/pull request for [adding support](CONTRIBUTING.md) for another model of printer, with logs from `wicreset` or similar attached.
 
 The format for reading values is:
 

--- a/models.json
+++ b/models.json
@@ -143,5 +143,18 @@
       {"oids": [20, 21], "total": null},
       {"oids": [18, 19], "total": 2081.25}
     ]
+  },
+  "EPSON ET-2750": {
+    "password": [73, 8], 
+    "eeprom_link": "1.3.6.1.4.1.1248.1.2.2.44.1.1.2.1",
+    "eeprom_write": "66.115.98.111.117.106.103.112", 
+    "ink_levels": {}, 
+    "waste_inks": [
+      {"oids": [48, 49], "total": 10912.5},
+      {"oids": [52, 53], "total": null},
+      {"oids": [50, 51], "total": 1630.0}
+    ], 
+    "maintenance_levels": [54, 55],
+    "unknown_oids": [47, 28]
   }
 }


### PR DESCRIPTION
I had trouble following the procedure because I could only get the python dependances trough Docker. I wrote a detailed procedure on how to use the project in Docker to get the OIDs of a printer. There is a few things I had to search, such as the `--entrypoint "/bin/sh"` argument to run the `python wicreset.py --json /usr/src/app/wicreset/application.log` command. **I will make a separate pull request later.**
I first tried using the profile for the `EPSON ET-2700` but didn't reset the WIC counter of my `EPSON ET-2750` when rebooting it. Therefore I went ahead and used WICreset, which worked but I just noticed that the data I obtained with the log file are the same that the one of the `EPSON ET-2700`.

I don't know if my profile for my `EPSON ET-2750` is working because I don't know how to read the value of the WIC, is it 0%(my profile worked) or 80%(only WICreset worked) ?
I had wireshark recording the SNMP packets when resetting the WIC, reading some values and dumping the eeprom, if that can be useful.

Thank you for this amazing project