### PR TITLE
Add EPSON L365 Series

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ To compare, `wicreset` writes the following values for the specified model of pr
 | ---------- | ---------- |
 | ET-2700    | ET-2550    |
 | ET-2750    | L3150      |
-| ET-2756    | L366       |
-| ET-4700    | L455       |
-| L3060      | L655       |
-| WF-7525    |            |
+| ET-2756    | L365       |
+| ET-4700    | L366       |
+| L3060      | L455       |
+| WF-7525    | L655       |
 | XP-422     |            |
 | XP-520     |            |
 | XP-540     |            |
@@ -104,7 +104,7 @@ Model not listed? See this [guide](CONTRIBUTING.md) by [@j6ta](https://github.co
 
 The key, `trial`, can be used to reset your counters to 80% for free. After packet sniffing with `wireshark`, the correct OIDs can be found.
 
-The application also stores a log containing SNMP information at `~/.wicreset/application.log` on Linux-based systems, `%APPDATA%\wicreset\application.log` on Windows or `~/Library/Application Support/wicreset/` for Mac OS. 
+The application also stores a log containing SNMP information at `~/.wicreset/application.log` on Linux-based systems, `%APPDATA%\wicreset\application.log` on Windows or `~/Library/Application Support/wicreset/` for Mac OS.
 
 Once the log has been found, you can use `wicreset.py <path to log>` to automatically parse and guess the OID structure of your printer.
 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ To compare, `wicreset` writes the following values for the specified model of pr
 | ---------- | ---------- |
 | ET-2700    | ET-2550    |
 | ET-2750    | L3150      |
-| ET-2756    | L365       |
-| ET-4700    | L366       |
-| L3060      | L455       |
-| WF-7525    | L655       |
+| ET-2756    | L366       |
+| ET-4700    | L455       |
+| L3060      | L655       |
+| L365       |            |
+| WF-7525    |            |
 | XP-422     |            |
 | XP-520     |            |
 | XP-540     |            |

--- a/models.json
+++ b/models.json
@@ -89,6 +89,18 @@
       {"oids": [50, 51], "total": 3415.0}
     ]
   },
+  "EPSON L365": {
+    "eeprom_link": "1.3.6.1.4.1.1248.1.2.2.44.1.1.2.1",
+    "eeprom_write": "72.102.115.99.102.115.98.43",
+    "ink_levels": {},
+    "maintenance_levels": [46],
+    "password": [130, 2],
+    "unknown_oids": [],
+    "waste_inks": [
+      {"oids": [24, 25, 30], "total": 6206.25},
+      {"oids": [28, 29], "total": null}
+    ]
+  },
   "EPSON L366": {
     "eeprom_link": "1.3.6.1.4.1.1248.1.2.2.44.1.1.2.1",
     "eeprom_write": "72.102.115.99.102.115.98.43",


### PR DESCRIPTION
Added and tested EPSON L365 Series.

## Some outputs

```text
$ python main.py 192.168.0.27 'EPSON L365'

{'eeps2_version': 'EEPS2 Hard Ver.1.00 Firm Ver.0.73',
'ink_levels': {},
'model_full': 'EPSON L365 Series',
'serial_number': ''**********',
'waste_ink_levels': [74.97]}
```

```text
$ python main.py 192.168.0.27 'EPSON L365' --dump

 [...]
 250: 0,
 251: 0,
 252: 153,
 253: 197,
 254: 145}
{'eeps2_version': 'EEPS2 Hard Ver.1.00 Firm Ver.0.73',
 'ink_levels': {},
 'model_full': 'EPSON L365 Series',
 'serial_number': ''**********',
 'waste_ink_levels': [74.97]}
```

```text
$ python main.py 192.168.0.27 'EPSON L365' --brute-force

[...]
Trying [129, 253]...
Trying [129, 254]...
Trying [130, 0]...
Trying [130, 1]...
Trying [130, 2]...
Password found: [130, 2]
{'eeps2_version': 'EEPS2 Hard Ver.1.00 Firm Ver.0.73',
 'ink_levels': {},
 'model_full': 'EPSON L365 Series',
 'serial_number': ''**********',
 'waste_ink_levels': [74.97]}
```

```text
$ python main.py 192.168.0.27 'EPSON L365' --reset

{'eeps2_version': 'EEPS2 Hard Ver.1.00 Firm Ver.0.73',
 'ink_levels': {},
 'model_full': 'EPSON L365 Series',
 'serial_number': '**********',
 'waste_ink_levels': [0.0]}
```

## `application.log`

I'm also including the following `application.log` snippet from the WIC Reset Utility for those who are interested:

```text
[...]
Core::EpsonRemoteResetData Reset started. Do not turn off the printer.
RemoteControl::RESET_GUID RESET GUID: L365 Series 376 KEY
RemoteControl::RESET_DATA RESET DATA: 0 - 7C 7C 10 00 82 02 42 BD 21 18 00 65 48 66 73 63 66 73 62 2B REAL
EpsonCommonIONET::perform SNMP [SEND]: 7C 7C 10 00 82 02 42 BD 21 18 00 65 48 66 73 63 66 73 62 2B
EpsonCommonIONET::perform SNMP [READ]: 7C 7C 3A 34 32 3A 4F 4B 3B 0C
RemoteControl::RESET_DATA RESET DATA: 1 - 7C 7C 10 00 82 02 42 BD 21 19 00 13 48 66 73 63 66 73 62 2B REAL
EpsonCommonIONET::perform SNMP [SEND]: 7C 7C 10 00 82 02 42 BD 21 19 00 13 48 66 73 63 66 73 62 2B
EpsonCommonIONET::perform SNMP [READ]: 7C 7C 3A 34 32 3A 4F 4B 3B 0C
RemoteControl::RESET_DATA RESET DATA: 2 - 7C 7C 10 00 82 02 42 BD 21 1E 00 00 48 66 73 63 66 73 62 2B REAL
EpsonCommonIONET::perform SNMP [SEND]: 7C 7C 10 00 82 02 42 BD 21 1E 00 00 48 66 73 63 66 73 62 2B
EpsonCommonIONET::perform SNMP [READ]: 7C 7C 3A 34 32 3A 4F 4B 3B 0C
RemoteControl::RESET_DATA RESET DATA: 3 - 7C 7C 10 00 82 02 42 BD 21 1C 00 00 48 66 73 63 66 73 62 2B REAL
EpsonCommonIONET::perform SNMP [SEND]: 7C 7C 10 00 82 02 42 BD 21 1C 00 00 48 66 73 63 66 73 62 2B
EpsonCommonIONET::perform SNMP [READ]: 7C 7C 3A 34 32 3A 4F 4B 3B 0C
RemoteControl::RESET_DATA RESET DATA: 4 - 7C 7C 10 00 82 02 42 BD 21 1D 00 00 48 66 73 63 66 73 62 2B REAL
EpsonCommonIONET::perform SNMP [SEND]: 7C 7C 10 00 82 02 42 BD 21 1D 00 00 48 66 73 63 66 73 62 2B
EpsonCommonIONET::perform SNMP [READ]: 7C 7C 3A 34 32 3A 4F 4B 3B 0C
RemoteControl::RESET_DATA RESET DATA: 5 - 7C 7C 10 00 82 02 42 BD 21 2E 00 5E 48 66 73 63 66 73 62 2B REAL
EpsonCommonIONET::perform SNMP [SEND]: 7C 7C 10 00 82 02 42 BD 21 2E 00 5E 48 66 73 63 66 73 62 2B
EpsonCommonIONET::perform SNMP [READ]: 7C 7C 3A 34 32 3A 4F 4B 3B 0C
RemoteControl::RESET_DATA RESET DATA: 6 - FF REAL
Core::EpsonRemoteResetData Reset complete. Please restart the printer immediately.
[...]
```