### PR TITLE
Support for XP-332 335 Series

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3-alpine
+FROM python:3-slim
 
 WORKDIR /usr/src/app
 COPY main.py models.json requirements.txt .
 
-RUN apk add --no-cache build-base net-snmp net-snmp-dev
+# dependencies for easysnmp
+RUN apt-get update && apt-get install -y \
+	gcc \
+	libsnmp-dev \
+	snmp \
+	&& rm -rf /var/lib/apt/lists/*
+
 RUN pip install --no-cache-dir -r requirements.txt
 
 ENTRYPOINT ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ To compare, `wicreset` writes the following values for the specified model of pr
 | L386    | XP-323     |
 | WF-7525 | XP-325     |
 | XP-322  | XP-530     |
+| XP-332  | XP-335     |
 | XP-352  |            |
 | XP-355  |            |
 | XP-422  |            |
@@ -162,7 +163,9 @@ A minimal Dockerfile is provided to easily build an image with the relevant `net
 
 Build: `docker build -t "epson-printer-snmp" .`
 
-Run: `docker run -it --rm "epson-printer-snmp"`
+Run dump info: `docker run -it --rm "epson-printer-snmp"`
+
+Run execute reset: `docker run -it --rm "epson-printer-snmp" -r`
 
 ## Libraries
 

--- a/models.json
+++ b/models.json
@@ -206,6 +206,19 @@
       {"oids": [26, 27], "total": 3255.0}
     ]
   },
+  "XP-332 335 Series": {
+    "eeprom_link": "1.3.6.1.4.1.1248.1.2.2.44.1.1.2.1",
+    "eeprom_write": "81.112.109.122.121.102.111.98",
+    "ink_levels": {},
+    "maintenance_levels": [46, 47],
+    "password": [133, 5],
+    "unknown_oids": [30, 34, 49],
+    "waste_inks": [
+      {"oids": [24, 25], "total": 3990.0},
+      {"oids": [28, 29], "total": null},
+      {"oids": [26, 27], "total": 3255.0}
+    ]
+  },
   "EPSON XP-352": {
     "eeprom_link": "1.3.6.1.4.1.1248.1.2.2.44.1.1.2.1",
     "eeprom_write": "84.118.115.98.110.98.101.118",


### PR DESCRIPTION
I’ve confirmed that it works for 332. I also made some changes to the Dockerfile because I couldn’t build it properly. Additionally, I added some information to the readme about how to run and reset the waste tank. It wasn’t clear to me that by default script only dumps information and doesn’t perform a reset.