### PR TITLE
Add EP-808A Series

### DIFF
--- a/models.json
+++ b/models.json
@@ -321,5 +321,18 @@
       {"oids": [28, 29], "total": null},
       {"oids": [26, 27], "total": 3255.0}
     ]
+  },
+  "EP-808A Series": {
+    "eeprom_link": "1.3.6.1.4.1.1248.1.2.2.44.1.1.2.1",
+    "eeprom_write": "74.115.106.116.104.98.115.110",
+    "ink_levels": {},
+    "maintenance_levels": [52, 53],
+    "password": [40, 9],
+    "unknown_oids": [6, 237],
+    "waste_inks": [
+      {"oids": [16, 17], "total": null},
+      {"oids": [20, 21], "total": null},
+      {"oids": [18, 19], "total": null}
+    ]
   }
 }


### PR DESCRIPTION
`waste_inks` values are unknown. Perhaps it's because I used the paid key for running WicReset.

On the other hand, I have some log files that contains the result of "Read waste counter(s)". I don't know whether the information is useful or not, but I post the log entries just in case.
* [Log entries when each waste counters are 96.49% and 8.19%](https://gist.github.com/grj1234/a1cdfe9de9d21e1c8ab5769f6066b865)
* [Log entries when both waste counters are 0.00%](https://gist.github.com/grj1234/866c9e8cc3ad408ca1fd44a5366360ba)
