### PR TITLE
Add Support for ET-2600 Series Printers

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,16 +88,17 @@ To compare, `wicreset` writes the following values for the specified model of pr
 | Tested  | Not tested |
 | ------- | ---------- |
 | ET-2500 | ET-2550    |
-| ET-2700 | L3150      |
-| ET-2750 | L366       |
-| ET-2756 | L455       |
-| ET-4700 | L655       |
-| L3060   | XP-255     |
-| L365    | XP-257     |
-| L386    | XP-323     |
-| WF-7525 | XP-325     |
-| XP-322  | XP-335     |
-| XP-332  | XP-530     |
+| ET-2600 | L3150      |
+| ET-2700 | L366       |
+| ET-2750 | L455       |
+| ET-2756 | L655       |
+| ET-4700 | XP-255     |
+| L3060   | XP-257     |
+| L365    | XP-323     |
+| L386    | XP-325     |
+| WF-7525 | XP-335     |
+| XP-322  | XP-530     |
+| XP-332  |            |
 | XP-352  |            |
 | XP-355  |            |
 | XP-422  |            |

--- a/models.json
+++ b/models.json
@@ -36,6 +36,18 @@
       {"oids": [28, 29], "total": null}
     ]
   },
+  "EPSON ET-2600 Series": {
+    "eeprom_link": "1.3.6.1.4.1.1248.1.2.2.44.1.1.2.1",
+    "eeprom_write": "84.106.111.98.99.118.111.104",
+    "ink_levels": {},
+    "maintenance_levels": [46],
+    "password": [16, 8],
+    "unknown_oids": [30],
+    "waste_inks": [
+      {"oids": [24, 25], "total": 6206.25},
+      {"oids": [28, 29], "total": null}
+    ]
+  },
   "EPSON ET-2700": {
     "eeprom_link": "1.3.6.1.4.1.1248.1.2.2.44.1.1.2.1",
     "eeprom_write": "66.115.98.111.117.106.103.112",


### PR DESCRIPTION
Hi there,

I followed to guide in CONTRIBUTING.md to add support for my ET-2600 printer.
The values were obtained using the "TRIAL" key in WICReset and manually extracting the information from the log file.

I also added the model number to the README.md as it tested successfully on my printer. 

Cheers!