### PR TITLE
Add EPSON XP-243 245 247 Series model data

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,14 @@ To compare, `wicreset` writes the following values for the specified model of pr
 | ET-2700 | L366       |
 | ET-2750 | L455       |
 | ET-2756 | L655       |
-| ET-4700 | XP-255     |
-| L3060   | XP-257     |
-| L355    | XP-323     |
-| L365    | XP-325     |
-| L386    | XP-335     |
-| WF-7525 | XP-530     |
-| XP-322  |            |
+| ET-4700 | XP-243     |
+| L3060   | XP-247     |
+| L355    | XP-255     |
+| L365    | XP-257     |
+| L386    | XP-323     |
+| WF-7525 | XP-325     |
+| XP-245  | XP-335     |
+| XP-322  | XP-530     |
 | XP-332  |            |
 | XP-352  |            |
 | XP-355  |            |

--- a/models.json
+++ b/models.json
@@ -218,6 +218,19 @@
       {"oids": [24, 25], "total": null}
     ]
   },
+  "EPSON XP-243 245 247 Series": {
+    "eeprom_link": "1.3.6.1.4.1.1248.1.2.2.44.1.1.2.1",
+    "eeprom_write": "84.118.115.98.110.98.101.118",
+    "ink_levels": {},
+    "maintenance_levels": [46, 47],
+    "password": [1, 5],
+    "unknown_oids": [30, 34, 49],
+    "waste_inks": [
+      { "oids": [24, 25], "total": 3990.0 },
+      { "oids": [28, 29], "total": null },
+      { "oids": [26, 27], "total": 3254.9999999999995 }
+    ]
+  },
   "EPSON XP-255 257 Series": {
     "eeprom_link": "1.3.6.1.4.1.1248.1.2.2.44.1.1.2.1",
     "eeprom_write": "84.118.115.98.110.98.101.118",

--- a/models.json
+++ b/models.json
@@ -228,7 +228,7 @@
     "waste_inks": [
       { "oids": [24, 25], "total": 3990.0 },
       { "oids": [28, 29], "total": null },
-      { "oids": [26, 27], "total": 3254.9999999999995 }
+      { "oids": [26, 27], "total": 3255 }
     ]
   },
   "EPSON XP-255 257 Series": {


### PR DESCRIPTION
Hello,

I just ran the `wicreset.py` utility on the `application.log` generated from my EPSON XP-245 printer and here's the data. I also added `EPSON ` in front of the key name in the json file to make it in par with the reset of the keys, not sure if it's important or not not to edit those.

I successfully reset the ink tank counter with this repo's code, thank you!