### PR TITLE
models.json: add ET-2810 series

### DIFF
--- a/models.json
+++ b/models.json
@@ -397,5 +397,17 @@
       {"oids": [18, 19], "total": 3370.0},
       {"oids": [20, 21], "total": null}
     ]
+  },
+  "EPSON ET-2810": {
+    "eeprom_link": "1.3.6.1.4.1.1248.1.2.2.44.1.1.2.1",
+    "eeprom_write": "78.98.115.106.99.98.122.98",
+    "ink_levels": {},
+    "maintenance_levels": [54, 55, 255],
+    "password": [74, 54],
+    "unknown_oids": [47, 52, 53, 28, 252, 253, 254],
+    "waste_inks": [
+      {"oids": [48, 49], "total": 6345.0},
+      {"oids": [50, 51], "total": 3415.0}
+    ]
   }
 }


### PR DESCRIPTION
May work on ET-2811, ET-2813 and ET-2815, but untested.