### PR TITLE
Add Epson L3050 series data

### DIFF
--- a/models.json
+++ b/models.json
@@ -125,6 +125,19 @@
       {"oids": [50, 51], "total": 3415.0}
     ]
   },
+  "EPSON L3050 Series": {
+    "eeprom_link": "1.3.6.1.4.1.1248.1.2.2.44.1.1.2.1",
+    "eeprom_write": "84.106.111.98.99.118.111.104",
+    "ink_levels": {},
+    "maintenance_levels": [46, 47],
+    "password": [16, 8],
+    "unknown_oids": [30, 34],
+    "waste_inks": [
+      {"oids": [24, 25], "total": 6206.25},
+      {"oids": [28, 29], "total": null},
+      {"oids": [26, 27], "total": 2420.0}
+    ]
+  },
   "EPSON L3060 Series": {
     "eeprom_link": "1.3.6.1.4.1.1248.1.2.2.44.1.1.2.1",
     "eeprom_write": "78.98.111.106.111.107.98.118",


### PR DESCRIPTION
* Added support for the **Epson L3050** series in `models.json`
* Model data acquired using `wicreset.py`
* Verified on my Epson L3050 (`EEPS2 Hard Ver.1.00 Firm Ver.0.30`)